### PR TITLE
refactor routes to Laravel 9 style

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -20,34 +20,20 @@ class RouteServiceProvider extends ServiceProvider
     public const HOME = '/home';
 
     /**
-     * The controller namespace for the application.
-     *
-     * When present, controller route declarations will automatically be prefixed with this namespace.
-     *
-     * @var string|null
-     */
-    // protected $namespace = 'App\\Http\\Controllers';
-
-    /**
      * Define your route model bindings, pattern filters, etc.
-     *
-     * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->configureRateLimiting();
 
         $this->routes(function () {
-            Route::prefix('api')
-                ->middleware('api')
-                ->namespace($this->namespace)
+            Route::middleware('api')
+                ->prefix('api')
                 ->group(base_path('routes/api.php'));
 
             Route::middleware('web')
-                ->namespace($this->namespace)
                 ->group(base_path('routes/web.php'));
         });
-
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,10 +14,9 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::group(['middleware' => ['redesimAuth']], function () {
-    //redesim
-    Route::group(['prefix' => 'redesim'], function () {
+Route::middleware('redesimAuth')
+    ->prefix('redesim')
+    ->group(function () {
         Route::post('/companies', [RedesimController::class, 'index'])
             ->name('redesim.companies');
     });
-});

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,36 +6,39 @@ use App\Http\Controllers\RedesimController;
 use App\Http\Controllers\Modules\Patrimonial\Licitacoes\Procedimentos\JulgamentoPorLance\FaseDeLances\FaseDeLancesController;
 use Illuminate\Support\Facades\Route;
 
-Route::group(['middleware' => ['legacySession', 'authEcidadeUser', 'auth.basic'], 'prefix' => 'web'], function () {
-    Route::get('/welcome', function () {
-        return view('modelo');
-    })->name('welcome');
-    Route::post('iptufoto/upload', [IptuFotosController::class, 'upload'])->name('iptufotos-upload');
-    Route::get('iptufoto/list/{matric}', [IptuFotosController::class, 'list'])->name('iptufotos-list');
-    Route::post('iptufoto/update', [IptuFotosController::class, 'update'])->name('iptufotos-update');
-    Route::delete('iptufoto/delete/{id}/{matric}', [IptuFotosController::class, 'delete'])->name('iptufotos-delete');
-    Route::get('iptufoto/show/{id}', [IptuFotosController::class, 'show'])->name('iptufotos-show');
+Route::middleware(['legacySession', 'authEcidadeUser', 'auth.basic'])
+    ->prefix('web')
+    ->group(function () {
+        Route::get('/welcome', function () {
+            return view('modelo');
+        })->name('welcome');
+        Route::post('iptufoto/upload', [IptuFotosController::class, 'upload'])->name('iptufotos-upload');
+        Route::get('iptufoto/list/{matric}', [IptuFotosController::class, 'list'])->name('iptufotos-list');
+        Route::post('iptufoto/update', [IptuFotosController::class, 'update'])->name('iptufotos-update');
+        Route::delete('iptufoto/delete/{id}/{matric}', [IptuFotosController::class, 'delete'])->name('iptufotos-delete');
+        Route::get('iptufoto/show/{id}', [IptuFotosController::class, 'show'])->name('iptufotos-show');
 
-    //audit
-    Route::get('/audits', [AuditController::class, 'index'])->name('audits.index');
+        //audit
+        Route::get('/audits', [AuditController::class, 'index'])->name('audits.index');
 
-    //redesim
-    Route::group(['prefix' => 'redesim'], function () {
-        Route::post('/companiesReport', [RedesimController::class, 'companiesReport'])
-            ->name('redesim.companies.report');
-        Route::get('/alvara', [RedesimController::class, 'alvara'])
-            ->name('redesim.alvara');
-        Route::post('/alvara/create', [RedesimController::class, 'create'])
-            ->name('redesim.alvara.create');
+        //redesim
+        Route::prefix('redesim')->group(function () {
+            Route::post('/companiesReport', [RedesimController::class, 'companiesReport'])
+                ->name('redesim.companies.report');
+            Route::get('/alvara', [RedesimController::class, 'alvara'])
+                ->name('redesim.alvara');
+            Route::post('/alvara/create', [RedesimController::class, 'create'])
+                ->name('redesim.alvara.create');
+        });
+
+        require base_path('routes/modules/patrimonial/patrimonial.php');
+        require base_path('routes/modules/configuracao/configuracao.php');
+
+        Route::prefix('datagrid')->group(function () {
+            Route::get('/get-liclicita', [FaseDeLancesController::class, 'getLiclicita'])->name('datagrid.getLiclicita');
+            Route::get('/get-liclicita-item', [FaseDeLancesController::class, 'getLiclicitaItens'])->name('datagrid.getLiclicitaItens');
+        });
     });
-    require base_path('routes/modules/patrimonial/patrimonial.php');
-    require base_path('routes/modules/configuracao/configuracao.php');
-
-    Route::prefix('datagrid')->group(function () {
-        Route::get('/get-liclicita', [FaseDeLancesController::class, 'getLiclicita'])->name('datagrid.getLiclicita');
-        Route::get('/get-liclicita-item', [FaseDeLancesController::class, 'getLiclicitaItens'])->name('datagrid.getLiclicitaItens');
-    });
-});
 
 Route::fallback(function () {
     abort(404);


### PR DESCRIPTION
## Summary
- remove deprecated namespace configuration from RouteServiceProvider
- refactor API and web route groups to fluent Laravel 9 style

## Testing
- `composer test` *(fails: Could not open input file vendor/composer/bin/phpunit)*

------
https://chatgpt.com/codex/tasks/task_e_689b2de76b6083309bdf1a7ce54c5950