### PR TITLE
Atualiza módulo de água para PHP 8.4

### DIFF
--- a/agua/agu1_aguacorte001.php
+++ b/agua/agu1_aguacorte001.php
@@ -1,4 +1,4 @@
-<?
+<?php
 require("libs/db_stdlib.php");
 require("libs/db_conecta.php");
 include("libs/db_sessoes.php");
@@ -27,20 +27,20 @@ $db_opcao = 1;
 </table>
 <table valign="top" marginwidth="0" width="790" border="0" cellspacing="0" cellpadding="0">
   <tr> 
-    <td height="430" align="left" valign="top" bgcolor="#CCCCCC"> 
-     <?
-	 $clcriaabas->identifica = array("aguacorte"=>"Criterios","aguacortemat"=>"Imoveis","aguacortetipodebito"=>"Tipo Debito"); 
-	 $clcriaabas->src = array("aguacorte"=>"agu1_aguacorte004.php");
-	 $clcriaabas->disabled   =  array("aguacortemat"=>"true","aguacortetipodebito"=>"true"); 
-	 $clcriaabas->cria_abas(); 
-       ?> 
-       </td>
+      <td height="430" align="left" valign="top" bgcolor="#CCCCCC">
+       <?php
+          $clcriaabas->identifica = array("aguacorte"=>"Criterios","aguacortemat"=>"Imoveis","aguacortetipodebito"=>"Tipo Debito");
+          $clcriaabas->src = array("aguacorte"=>"agu1_aguacorte004.php");
+          $clcriaabas->disabled   =  array("aguacortemat"=>"true","aguacortetipodebito"=>"true");
+          $clcriaabas->cria_abas();
+        ?>
+        </td>
     </tr>
   </table>
   <form name="form1">
-  </form>
-      <? 
-	db_menu(db_getsession("DB_id_usuario"),db_getsession("DB_modulo"),db_getsession("DB_anousu"),db_getsession("DB_instit"));
-      ?>
+    </form>
+        <?php
+          db_menu(db_getsession("DB_id_usuario"),db_getsession("DB_modulo"),db_getsession("DB_anousu"),db_getsession("DB_instit"));
+        ?>
   </body>
   </html>

--- a/agua/agu1_aguacorte002.php
+++ b/agua/agu1_aguacorte002.php
@@ -1,4 +1,4 @@
-<?
+<?php
 require("libs/db_stdlib.php");
 require("libs/db_conecta.php");
 include("libs/db_sessoes.php");
@@ -27,21 +27,21 @@ $db_opcao = 1;
 </table>
 <table valign="top" marginwidth="0" width="790" border="0" cellspacing="0" cellpadding="0">
   <tr> 
-    <td height="430" align="left" valign="top" bgcolor="#CCCCCC"> 
-     <?
-	 //$clcriaabas->identifica = array("aguacorte"=>"aguacorte","aguacortemat"=>"aguacortemat","aguacortetipodebito"=>"aguacortetipodebito"); 
-	 $clcriaabas->identifica = array("aguacorte"=>"Criterios","aguacortemat"=>"Imoveis","aguacortetipodebito"=>"Tipo Debito"); 
-	 $clcriaabas->src = array("aguacorte"=>"agu1_aguacorte005.php");
-	 $clcriaabas->disabled   =  array("aguacortemat"=>"true","aguacortetipodebito"=>"true"); 
-	 $clcriaabas->cria_abas(); 
-       ?> 
-       </td>
+      <td height="430" align="left" valign="top" bgcolor="#CCCCCC">
+       <?php
+          //$clcriaabas->identifica = array("aguacorte"=>"aguacorte","aguacortemat"=>"aguacortemat","aguacortetipodebito"=>"aguacortetipodebito");
+          $clcriaabas->identifica = array("aguacorte"=>"Criterios","aguacortemat"=>"Imoveis","aguacortetipodebito"=>"Tipo Debito");
+          $clcriaabas->src = array("aguacorte"=>"agu1_aguacorte005.php");
+          $clcriaabas->disabled   =  array("aguacortemat"=>"true","aguacortetipodebito"=>"true");
+          $clcriaabas->cria_abas();
+        ?>
+        </td>
     </tr>
   </table>
   <form name="form1">
-  </form>
-      <? 
-	db_menu(db_getsession("DB_id_usuario"),db_getsession("DB_modulo"),db_getsession("DB_anousu"),db_getsession("DB_instit"));
-      ?>
+    </form>
+        <?php
+          db_menu(db_getsession("DB_id_usuario"),db_getsession("DB_modulo"),db_getsession("DB_anousu"),db_getsession("DB_instit"));
+        ?>
   </body>
   </html>

--- a/agua/agu1_aguacorte003.php
+++ b/agua/agu1_aguacorte003.php
@@ -1,4 +1,4 @@
-<?
+<?php
 require("libs/db_stdlib.php");
 require("libs/db_conecta.php");
 include("libs/db_sessoes.php");
@@ -27,21 +27,21 @@ $db_opcao = 1;
 </table>
 <table valign="top" marginwidth="0" width="790" border="0" cellspacing="0" cellpadding="0">
   <tr> 
-    <td height="430" align="left" valign="top" bgcolor="#CCCCCC"> 
-     <?
-	 //$clcriaabas->identifica = array("aguacorte"=>"aguacorte","aguacortemat"=>"aguacortemat","aguacortetipodebito"=>"aguacortetipodebito"); 
-	 $clcriaabas->identifica = array("aguacorte"=>"Criterios","aguacortemat"=>"Imoveis","aguacortetipodebito"=>"Tipo Debito"); 
-	 $clcriaabas->src = array("aguacorte"=>"agu1_aguacorte006.php");
-	 $clcriaabas->disabled   =  array("aguacortemat"=>"true","aguacortetipodebito"=>"true"); 
-	 $clcriaabas->cria_abas(); 
-       ?> 
-       </td>
+      <td height="430" align="left" valign="top" bgcolor="#CCCCCC">
+       <?php
+          //$clcriaabas->identifica = array("aguacorte"=>"aguacorte","aguacortemat"=>"aguacortemat","aguacortetipodebito"=>"aguacortetipodebito");
+          $clcriaabas->identifica = array("aguacorte"=>"Criterios","aguacortemat"=>"Imoveis","aguacortetipodebito"=>"Tipo Debito");
+          $clcriaabas->src = array("aguacorte"=>"agu1_aguacorte006.php");
+          $clcriaabas->disabled   =  array("aguacortemat"=>"true","aguacortetipodebito"=>"true");
+          $clcriaabas->cria_abas();
+        ?>
+        </td>
     </tr>
   </table>
   <form name="form1">
-  </form>
-      <? 
-	db_menu(db_getsession("DB_id_usuario"),db_getsession("DB_modulo"),db_getsession("DB_anousu"),db_getsession("DB_instit"));
-      ?>
+    </form>
+        <?php
+          db_menu(db_getsession("DB_id_usuario"),db_getsession("DB_modulo"),db_getsession("DB_anousu"),db_getsession("DB_instit"));
+        ?>
   </body>
   </html>

--- a/agua/agu1_aguacortetipodebito001.php
+++ b/agua/agu1_aguacortetipodebito001.php
@@ -1,4 +1,4 @@
-<?
+<?php
 require("libs/db_stdlib.php");
 require("libs/db_conecta.php");
 include("libs/db_sessoes.php");
@@ -6,8 +6,8 @@ include("libs/db_usuariosonline.php");
 include("classes/db_aguacortetipodebito_classe.php");
 include("classes/db_aguacorte_classe.php");
 include("dbforms/db_funcoes.php");
-parse_str($HTTP_SERVER_VARS["QUERY_STRING"]);
-db_postmemory($HTTP_POST_VARS);
+parse_str($_SERVER["QUERY_STRING"]);
+db_postmemory($_POST);
 $claguacortetipodebito = new cl_aguacortetipodebito;
 $claguacorte = new cl_aguacorte;
 $db_opcao = 22;
@@ -74,17 +74,17 @@ if(isset($incluir)){
 <table width="790" border="0" cellspacing="0" cellpadding="0">
   <tr> 
     <td height="430" align="left" valign="top" bgcolor="#CCCCCC"> 
-    <center>
-	<?
-	include("forms/db_frmaguacortetipodebito.php");
-	?>
+      <center>
+          <?php
+          include("forms/db_frmaguacortetipodebito.php");
+          ?>
     </center>
 	</td>
   </tr>
 </table>
 </body>
 </html>
-<?
+<?php
 if(isset($alterar) || isset($excluir) || isset($incluir)){
     db_msgbox($erro_msg);
     if($clpagordemrec->erro_campo!=""){

--- a/agua/agu1_aguacortetipodebito002.php
+++ b/agua/agu1_aguacortetipodebito002.php
@@ -1,12 +1,12 @@
-<?
+<?php
 require("libs/db_stdlib.php");
 require("libs/db_conecta.php");
 include("libs/db_sessoes.php");
 include("libs/db_usuariosonline.php");
 include("classes/db_aguacortetipodebito_classe.php");
 include("dbforms/db_funcoes.php");
-parse_str($HTTP_SERVER_VARS["QUERY_STRING"]);
-db_postmemory($HTTP_POST_VARS);
+parse_str($_SERVER["QUERY_STRING"]);
+db_postmemory($_POST);
 $claguacortetipodebito = new cl_aguacortetipodebito;
 $db_opcao = 22;
 $db_botao = false;
@@ -34,20 +34,20 @@ if(isset($alterar)){
 <table width="790" border="0" cellspacing="0" cellpadding="0">
   <tr> 
     <td height="430" align="left" valign="top" bgcolor="#CCCCCC"> 
-    <center>
-	<?
-	include("forms/db_frmaguacortetipodebito.php");
-	?>
+      <center>
+          <?php
+          include("forms/db_frmaguacortetipodebito.php");
+          ?>
     </center>
 	</td>
   </tr>
 </table>
-<?
+<?php
 //db_menu(db_getsession("DB_id_usuario"),db_getsession("DB_modulo"),db_getsession("DB_anousu"),db_getsession("DB_instit"));
 ?>
 </body>
 </html>
-<?
+<?php
 if(isset($alterar)){
   if($claguacortetipodebito->erro_status=="0"){
     $claguacortetipodebito->erro(true,false);

--- a/agua/agu1_aguacortetipodebito003.php
+++ b/agua/agu1_aguacortetipodebito003.php
@@ -1,12 +1,12 @@
-<?
+<?php
 require("libs/db_stdlib.php");
 require("libs/db_conecta.php");
 include("libs/db_sessoes.php");
 include("libs/db_usuariosonline.php");
 include("classes/db_aguacortetipodebito_classe.php");
 include("dbforms/db_funcoes.php");
-parse_str($HTTP_SERVER_VARS["QUERY_STRING"]);
-db_postmemory($HTTP_POST_VARS);
+parse_str($_SERVER["QUERY_STRING"]);
+db_postmemory($_POST);
 $claguacortetipodebito = new cl_aguacortetipodebito;
 $db_botao = false;
 $db_opcao = 33;
@@ -34,20 +34,20 @@ if(isset($excluir)){
 <table width="790" border="0" cellspacing="0" cellpadding="0">
   <tr> 
     <td height="430" align="left" valign="top" bgcolor="#CCCCCC"> 
-    <center>
-	<?
-	include("forms/db_frmaguacortetipodebito.php");
-	?>
+      <center>
+          <?php
+          include("forms/db_frmaguacortetipodebito.php");
+          ?>
     </center>
 	</td>
   </tr>
 </table>
-<?
+<?php
 //db_menu(db_getsession("DB_id_usuario"),db_getsession("DB_modulo"),db_getsession("DB_anousu"),db_getsession("DB_instit"));
 ?>
 </body>
 </html>
-<?
+<?php
 if(isset($excluir)){
   if($claguacortetipodebito->erro_status=="0"){
     $claguacortetipodebito->erro(true,false);


### PR DESCRIPTION
## Summary
- Substitui tags curtas `<?` por `<?php` nos arquivos do módulo de água
- Atualiza variáveis globais antigas para `$_SERVER` e `$_POST`

## Testing
- `php -l agua/agu1_aguacorte001.php`
- `php -l agua/agu1_aguacorte002.php`
- `php -l agua/agu1_aguacorte003.php`
- `php -l agua/agu1_aguacortetipodebito001.php`
- `php -l agua/agu1_aguacortetipodebito002.php`
- `php -l agua/agu1_aguacortetipodebito003.php`


------
https://chatgpt.com/codex/tasks/task_e_689c92d2d5fc8330b06705103ea09f4c